### PR TITLE
Fix Base64OutputStream on HHVM

### DIFF
--- a/src/main/php/module.xp
+++ b/src/main/php/module.xp
@@ -1,0 +1,11 @@
+<?php namespace text\encode;
+
+module xp-framework/text-encode {
+  
+  /** @return void */
+  public function initialize() {
+    if (defined('HHVM_VERSION')) {
+      class_alias(HHVMBase64OutputStream::class, Base64OutputStream::class);
+    }
+  }
+}

--- a/src/main/php/text/encode/HHVMBase64OutputStream.class.php
+++ b/src/main/php/text/encode/HHVMBase64OutputStream.class.php
@@ -1,0 +1,115 @@
+<?php namespace text\encode;
+
+use io\streams\OutputStream;
+use io\streams\Streams;
+use lang\Type;
+
+/**
+ * OuputStream that encodes data to base64 encoding
+ *
+ * @see      rfc://2045 section 6.8 
+ * @test     xp://net.xp_framework.unittest.text.encode.Base64OutputStreamTest
+ */
+class HHVMBase64OutputStream implements OutputStream {
+  const TABLE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+  const PAD = '=';
+
+  private $out, $remain;
+  private $pos= 0;
+  
+  /**
+   * Constructor
+   *
+   * @param   io.streams.OutputStream out
+   * @param   int lineLength limit maximum line length
+   */
+  public function __construct(OutputStream $out, $lineLength= 0) {
+    $this->out= $out;
+    $this->remain= '';
+    if ($lineLength) {
+      $pos= 0;
+      $this->write= function($bytes) use(&$pos, $lineLength) {
+        $l= strlen($bytes);
+        $o= 0;
+        while ($l - $o > $lineLength - $pos) {
+          $this->out->write(substr($bytes, $o, $lineLength - $pos)."\n");
+          $pos= 0;
+          $o+= $lineLength;
+        }
+        $this->out->write(substr($bytes, $o));
+        $pos= $l - $o;
+      };
+    } else {
+      $this->write= Type::forName('function(var): var')->cast([$this->out, 'write']);
+    }
+  }
+
+  /**
+   * Write a string
+   *
+   * @param   var arg
+   */
+  public function write($arg) {
+    $input= $this->remain.$arg;
+
+    $limit= strlen($input) - 2;
+    $encoded= '';
+    $offset= 0;
+    while ($offset < $limit) {
+      $encoded.= 
+        self::TABLE[ord($input{$offset}) >> 2].
+        self::TABLE[((ord($input{$offset}) & 0x03) << 4) + (ord($input{$offset + 1}) >> 4)].
+        self::TABLE[((ord($input{$offset + 1}) & 0x0f) << 2) + (ord($input{$offset + 2}) >> 6)].
+        self::TABLE[ord($input{$offset + 2}) & 0x3f]
+      ;
+      $offset+= 3;
+    }
+
+    $this->write->__invoke($encoded);
+    $this->remain= substr($input, $offset);
+  }
+
+  /**
+   * Flush this buffer
+   *
+   */
+  public function flush() {
+    $this->out->flush();
+  }
+
+  /**
+   * Close this buffer. Flushes this buffer and then calls the close()
+   * method on the underlying OuputStream.
+   *
+   */
+  public function close() {
+    switch (strlen($this->remain)) {
+      case 1:
+        $this->write->__invoke(
+          self::TABLE[ord($this->remain{0}) >> 2].
+          self::TABLE[(ord($this->remain{0}) & 0x03) << 4].
+          self::PAD.
+          self::PAD
+        );
+        break;
+      case 2:
+        $this->write->__invoke(
+          self::TABLE[ord($this->remain{0}) >> 2].
+          self::TABLE[((ord($this->remain{0}) & 0x03) << 4) + (ord($this->remain{1}) >> 4)].
+          self::TABLE[((ord($this->remain{1}) & 0x0f) << 2)].
+          self::PAD
+        );
+        break;
+    }
+    $this->out->close();
+    $this->remain= '';
+  }
+
+  /**
+   * Destructor. Ensures output stream is closed.
+   *
+   */
+  public function __destruct() {
+    $this->out->close();
+  }
+}

--- a/src/main/php/text/encode/HHVMBase64OutputStream.class.php
+++ b/src/main/php/text/encode/HHVMBase64OutputStream.class.php
@@ -1,7 +1,6 @@
 <?php namespace text\encode;
 
 use io\streams\OutputStream;
-use io\streams\Streams;
 use lang\Type;
 
 /**

--- a/src/test/php/text/encode/unittest/Base64OutputStreamTest.class.php
+++ b/src/test/php/text/encode/unittest/Base64OutputStreamTest.class.php
@@ -9,10 +9,7 @@ use text\encode\Base64OutputStream;
  *
  * @see   xp://text.encode.Base64OutputStream
  */
-#[@action([
-#  new VerifyThat(function() { return in_array("convert.*", stream_get_filters()); }),
-#  new VerifyThat(function() { return !defined('HHVM_VERSION'); })
-#])]
+#[@action(new VerifyThat(function() { return in_array("convert.*", stream_get_filters()); }))]
 class Base64OutputStreamTest extends \unittest\TestCase {
 
   /**


### PR DESCRIPTION
This pull request implements the base64 output stream in userland on HHVM, working around facebook/hhvm#7659. See xp-framework/core#176

I first went down the way of implementing a php_user_filter class and exchanging the stream filter with this implementation, however, its `filter()` method doesn't get invoked for the last chunk when the stream is closing due to facebook/hhvm#7889 - we need this to add potentially necessary padding.